### PR TITLE
Work around rpmbuild eagerness

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,3 @@
-#!/usr/bin/node
-
 var urlparse = require('./urlparse.js');
 
 var burl = urlparse("https://browserid.org:443/some/path/to/a/../doc.html");


### PR DESCRIPTION
rpmbuild looks for dependencies when building an RPM package. If a file has a shebang line, it'll add that as an explicit dependency. We've added awsbox to mozilla/butter, but the rpmbuild failed because /usr/bin/node doesn't exist on our servers, we build our own version of node. This patch simply removes the shebang so that we don't need to hack around it in butter.
