### PR TITLE
Allow including urlsparse as a member of a closure

### DIFF
--- a/urlparse.js
+++ b/urlparse.js
@@ -46,7 +46,7 @@
  *
  */
 
-(function() {
+(function(root) {
     /* const */ var INV_URL = "invalid url: ";
     var parseURL = function(s) {
         var toString = function() {
@@ -186,6 +186,6 @@
         return parseUri(s);
     };
 
-  if (typeof exports === 'undefined') window.URLParse = parseURL;
+  if (typeof exports === 'undefined') root.URLParse = parseURL;
   else module.exports = parseURL;
-})();
+})(this);


### PR DESCRIPTION
Currently the library is hardcoded to bind itself to window when not included on a commons JS project.

This patch allows the code to be bound to a custom closure. This make it possible to use the library on other runtimes like Rhino and include it on third party libraries without exposing it to the window.
